### PR TITLE
previous setVolumes may interfere w/ future ones

### DIFF
--- a/src/spc_player.js
+++ b/src/spc_player.js
@@ -150,6 +150,7 @@ SMWCentral.SPCPlayer.Backend = (function()
 			}
 			else
 			{
+				this.gainNode.gain.cancelScheduledValues(this.context.currentTime);
 				this.gainNode.gain.exponentialRampToValueAtTime(Math.min(Math.max(volume, 0.01), 1.5), this.context.currentTime + duration);
 			}
 		},


### PR DESCRIPTION
I created this patch a while ago and forgot to send a pull request upstream. Better late than never I guess.

When multiple calls to `.setVolume()` are done, and have a duration set, any further calls that are done before the previous ones have ended will result in strange volume behaviour. Adding this line will make it so calling this method will immediately cancel all ongoing volume changes and prioritize the new one.

p.s.: if you want the Node.js compatibility to be added upstream i can make a pull request / work on that too, it's just i don't know if the way it is coded now would be accepted