### PR TITLE
Reworked Player UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@smwcentral/spc-player",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "SMW Central's SPC player",
   "main": "dist/spc.js",
   "files": [
     "dist/"
-  ],  
+  ],
   "scripts": {
     "build": "./make.sh",
     "build-dev": "./make.sh --dev"

--- a/src/interface.js
+++ b/src/interface.js
@@ -55,8 +55,10 @@ function createSPCPlayerUI(){
 		restartBtn: player.querySelector(".restart"),
 
 		details: player.querySelector(".details"),
-		playlist: player.querySelector(".track-list"),
 		subtitles: player.getElementsByClassName("subtitle"),
+
+		trackListContainer: player.querySelector('#track-list-container'),
+		tracklist: player.querySelector(".track-list"),
 
 		seekContainer: player.querySelector(".seek-container"),
 		seekControl: player.querySelector(".seek"),
@@ -247,12 +249,11 @@ function createSPCPlayerUI(){
 		}
 
 		// fill track list
-
 		if(song.files.length > 1)
 		{
-			while(playerUI.playlist.lastChild !== null)
+			while(playerUI.tracklist.lastChild !== null)
 			{
-				playerUI.playlist.removeChild(playerUI.playlist.lastChild);
+				playerUI.tracklist.removeChild(playerUI.tracklist.lastChild);
 			}
 
 			const files = song.files;
@@ -269,14 +270,13 @@ function createSPCPlayerUI(){
 			const prefix = files[0].slice(0, common).lastIndexOf("/") + 1;
 
 			files.forEach((file, index) => {
-				playerUI.playlist.appendChild(SMWCentral.SPCPlayer.createPlaylistItem(song, file.slice(prefix), index));
+				playerUI.tracklist.appendChild(SMWCentral.SPCPlayer.createPlaylistItem(song, file.slice(prefix), index));
 			});
-
-			playerUI.playlist.classList.remove("hidden");
+			playerUI.trackListContainer.classList.remove("hidden");
 		}
 		else
 		{
-			playerUI.playlist.classList.add("hidden");
+			playerUI.trackListContainer.classList.add("hidden");
 		}
 
 		currentSong = song;
@@ -586,17 +586,46 @@ closeBtn.addEventListener("click", () => {
 	dragSPCPlayer(player, header).resetPosition();
 });
 
+// display an overflow indicator for long track lists
+function trackListOverflow() {
+	const player = document.getElementById("spc-player-interface");
+
+	const trackList = player.querySelector('#track-list-container');
+	const scrollbox = trackList.querySelector('.track-list-scrollbox');
+	const topIndicator = trackList.querySelector('.overflow-indicator.top');
+	const btmIndicator = trackList.querySelector('.overflow-indicator.bottom');
+
+	function updateOverflowDisplay() {
+		const { scrollTop, clientHeight, scrollHeight } = scrollbox;
+		topIndicator.classList.toggle('visible', scrollTop > 0);
+		btmIndicator.classList.toggle('visible', scrollTop + clientHeight < scrollHeight);
+	}
+
+	if (scrollbox.scrollHeight > scrollbox.clientHeight) {
+		btmIndicator.classList.add('visible');
+	}
+
+	const observer = new MutationObserver(() => updateOverflowDisplay());
+	observer.observe(scrollbox, { childList: true, subtree: true });
+
+	scrollbox.addEventListener('scroll', updateOverflowDisplay);
+
+	updateOverflowDisplay();
+}
+
 if(document.readyState === "loading")
 {
 	document.addEventListener("DOMContentLoaded", () => {
 		createSPCPlayerUI();
 		dragSPCPlayer(player, header);
+		trackListOverflow();
 	});
 }
 else
 {
 	createSPCPlayerUI();
 	dragSPCPlayer(player, header);
+	trackListOverflow();
 }
 
 })();

--- a/src/interface.js
+++ b/src/interface.js
@@ -197,21 +197,23 @@ function createSPCPlayerUI(){
 		const subtitleElements = player.getElementsByClassName("subtitle");
 
 		for (let i = 0; i < subtitleElements.length; i++) {
-			subtitleElements[i].innerText = subtitle.join(", ");
-			subtitleElements[i].style.display = (subtitle.length > 0) ? "block" : "none";
+			if (subtitle.length > 0) {
+				subtitleElements[i].innerHTML = "";
+				subtitleElements[i].innerText = subtitle.join(", ");
+			} else {
+				subtitleElements[i].innerHTML = '<i style="opacity:0.5;">No Track Info</i>';
+			}
 		}
 
 		// fill track details
-		const details = [];
+		const date = song.date.trim();
 		const detailsElement = player.querySelector(".details");
 
-		if(song.date.trim().length > 0)
-		{
-			details.push(`Exported on ${song.date}`);
+		if (date) {
+			detailsElement.innerText = `Exported on ${date}`;
+		} else {
+			detailsElement.innerHTML = '<i style="opacity:0.5;">No Track Details</i>';
 		}
-
-		detailsElement.style.display = (details.length > 0) ? "block" : "none";
-		detailsElement.innerText = details.join(", ");
 
 		// display duration
 		if(song.duration > 0)

--- a/src/interface.js
+++ b/src/interface.js
@@ -487,13 +487,109 @@ function createSPCPlayerUI(){
 	).then(loadSPC);
 };
 
+// function to allow the player window to be dragged
+function dragSPCPlayer(element, handle) {
+	let isDragging = false;
+	let startX = 0,
+		startY = 0;
+	let currentX = 0,
+		currentY = 0;
+	let offsetX = 0,
+		offsetY = 0;
+
+	// drag with mouse
+	handle.addEventListener("mousedown", (e) => {
+		if (e.target.closest(".header-button")) return;
+
+		e.preventDefault();
+		isDragging = true;
+
+		startX = e.clientX - offsetX;
+		startY = e.clientY - offsetY;
+
+		document.addEventListener("mousemove", onMouseMove);
+		document.addEventListener("mouseup", stopDragging);
+	});
+
+	function onMouseMove(e) {
+		if (!isDragging) return;
+
+		currentX = e.clientX - startX;
+		currentY = e.clientY - startY;
+		offsetX = currentX;
+		offsetY = currentY;
+
+		element.style.transform = `translate3d(${currentX}px, ${currentY}px, 0)`;
+	}
+
+	function stopDragging() {
+		isDragging = false;
+		document.removeEventListener("mousemove", onMouseMove);
+		document.removeEventListener("mouseup", stopDragging);
+	}
+
+	// drag on touch (on not phones)
+	if (window.innerWidth >= 768) {
+		handle.addEventListener("touchstart", (e) => {
+			if (e.target.closest(".header-button")) return;
+
+			isDragging = true;
+			const touch = e.touches[0];
+			startX = touch.clientX - offsetX;
+			startY = touch.clientY - offsetY;
+
+			document.addEventListener("touchmove", onTouchMove, {passive: false});
+			document.addEventListener("touchend", stopTouchDragging);
+		});
+
+		function onTouchMove(e) {
+			if (!isDragging) return;
+			e.preventDefault();
+
+			const touch = e.touches[0];
+			currentX = touch.clientX - startX;
+			currentY = touch.clientY - startY;
+			offsetX = currentX;
+			offsetY = currentY;
+
+			element.style.transform = `translate3d(${currentX}px, ${currentY}px, 0)`;
+		}
+
+		function stopTouchDragging() {
+			isDragging = false;
+			document.removeEventListener("touchmove", onTouchMove);
+			document.removeEventListener("touchend", stopTouchDragging);
+		}
+	}
+
+	// reset position
+	function resetPosition() {
+		offsetX = 0;
+		offsetY = 0;
+		element.style.transform = `translate3d(0,0,0)`;
+	}
+	return {resetPosition};
+}
+
+const player = document.getElementById("spc-player-interface");
+const header = player.querySelector("#spc-player-header");
+const closeBtn = player.querySelector(".close");
+
+closeBtn.addEventListener("click", () => {
+	dragSPCPlayer(player, header).resetPosition();
+});
+
 if(document.readyState === "loading")
 {
-	document.addEventListener("DOMContentLoaded", createSPCPlayerUI);
+	document.addEventListener("DOMContentLoaded", () => {
+		createSPCPlayerUI();
+		dragSPCPlayer(player, header);
+	});
 }
 else
 {
 	createSPCPlayerUI();
+	dragSPCPlayer(player, header);
 }
 
 })();

--- a/src/interface.js
+++ b/src/interface.js
@@ -48,20 +48,28 @@ function createSPCPlayerUI(){
 	const loop = document.getElementById("spc-player-loop");
 	const player = document.getElementById("spc-player-interface");
 
-	const pause = player.querySelector(".pause");
-	const play = player.querySelector(".play");
+	const playerUI = {
+		pauseBtn: player.querySelector(".pause"),
+		playBtn: player.querySelector(".play"),
+		stopBtn: player.querySelector(".stop"),
+		restartBtn: player.querySelector(".restart"),
 
-	const seekContainer = player.querySelector(".seek-container");
-	const seekControl = player.querySelector(".seek");
-	const seekPreview = player.querySelector(".seek-preview");
+		details: player.querySelector(".details"),
+		playlist: player.querySelector(".track-list"),
+		subtitles: player.getElementsByClassName("subtitle"),
 
-	const trackTimeElapsed = player.querySelector(".track-time-elapsed");
-	const trackDuration = player.querySelector(".track-duration");
+		seekContainer: player.querySelector(".seek-container"),
+		seekControl: player.querySelector(".seek"),
+		seekPreview: player.querySelector(".seek-preview"),
 
-	const volumeSlider = player.querySelector("#volume-slider");
-	const volumeLabel = player.querySelector(".volume-level");
-	const volumeFill = player.querySelector(".volume-fill");
-	const volumeThumb = player.querySelector(".volume-thumb");
+		trackTimeElapsed: player.querySelector(".track-time-elapsed"),
+		trackDuration: player.querySelector(".track-duration"),
+
+		volumeSlider: player.querySelector("#volume-slider"),
+		volumeLabel: player.querySelector(".volume-level"),
+		volumeFill: player.querySelector(".volume-fill"),
+		volumeThumb: player.querySelector(".volume-thumb")
+	};
 
 	let volume = Number(sessionStorage.getItem("spc_volume") || 1);
 
@@ -75,23 +83,23 @@ function createSPCPlayerUI(){
 		volume = 1;
 	}
 
-	volumeSlider.min = 0;
-	volumeSlider.max = 1.5;
-	volumeSlider.step = 0.01;
-	volumeSlider.value = volume;
+	playerUI.volumeSlider.min = 0;
+	playerUI.volumeSlider.max = 1.5;
+	playerUI.volumeSlider.step = 0.01;
+	playerUI.volumeSlider.value = volume;
 
 	const updateVolumeSlider = () => {
-		const trackWidth = volumeSlider.clientWidth;
+		const trackWidth = playerUI.volumeSlider.clientWidth;
 		const percent = volume / 1.5;
-		const thumbWidth = volumeThumb.getBoundingClientRect().width;
+		const thumbWidth = playerUI.volumeThumb.getBoundingClientRect().width;
 
 		if (!thumbWidth) return;
 
 		const clampedLeft = Math.min(trackWidth - thumbWidth / 2, Math.max(thumbWidth / 2, percent * trackWidth));
 
-		volumeFill.style.clipPath = `inset(0 ${100 - percent * 100}% 0 0)`;
-		volumeThumb.style.left = `${clampedLeft}px`;
-		volumeLabel.innerText = `${Math.round(volume * 100)}%`;
+		playerUI.volumeFill.style.clipPath = `inset(0 ${100 - percent * 100}% 0 0)`;
+		playerUI.volumeThumb.style.left = `${clampedLeft}px`;
+		playerUI.volumeLabel.innerText = `${Math.round(volume * 100)}%`;
 
 		SPCPlayer.setVolume(volume, Math.abs(SPCPlayer.getVolume() - volume) * 0.5);
 		sessionStorage.setItem("spc_volume", volume.toString());
@@ -100,7 +108,7 @@ function createSPCPlayerUI(){
 	const updateVolume = (event = null) => {
 		if(event instanceof Event && event.type === "input")
 		{
-			let newVolume = parseFloat(volumeSlider.value);
+			let newVolume = parseFloat(playerUI.volumeSlider.value);
 
 			if(Math.abs(newVolume - 1.5) < 0.05)
 			{
@@ -119,9 +127,9 @@ function createSPCPlayerUI(){
 		updateVolumeSlider();
 	};
 
-	volumeSlider.addEventListener("input", updateVolume);
+	playerUI.volumeSlider.addEventListener("input", updateVolume);
 
-	volumeSlider.addEventListener("wheel", (e) => {
+	playerUI.volumeSlider.addEventListener("wheel", (e) => {
 		e.preventDefault();
 		const step = 0.05;
 		if (e.deltaY < 0) {
@@ -129,14 +137,14 @@ function createSPCPlayerUI(){
 		} else {
 			volume = Math.max(0, volume - step);
 		}
-		volumeSlider.value = volume.toFixed(2);
+		playerUI.volumeSlider.value = volume.toFixed(2);
 		updateVolumeSlider();
 	});
 
 	// hack to set slider position on load
 	const initSlider = () => {
-		if (volumeThumb.getBoundingClientRect().width) {
-			volumeSlider.value = volume;
+		if (playerUI.volumeThumb.getBoundingClientRect().width) {
+			playerUI.volumeSlider.value = volume;
 			updateVolumeSlider();
 		} else {
 			requestAnimationFrame(initSlider);
@@ -184,8 +192,8 @@ function createSPCPlayerUI(){
 		SPCPlayer.loadSPC(new Uint8Array(song.spc), time);
 		updateVolume();
 
-		pause.classList.remove("hidden");
-		play.classList.add("hidden");
+		playerUI.pauseBtn.classList.remove("hidden");
+		playerUI.playBtn.classList.add("hidden");
 
 		const title = [song.game, song.title].filter((value) => value.trim().length > 0);
 		const titleElements = player.getElementsByClassName("title");
@@ -194,25 +202,23 @@ function createSPCPlayerUI(){
 		}
 
 		const subtitle = [song.author, song.comment].filter((value) => value.trim().length > 0);
-		const subtitleElements = player.getElementsByClassName("subtitle");
 
-		for (let i = 0; i < subtitleElements.length; i++) {
+		for (let i = 0; i < playerUI.subtitles.length; i++) {
 			if (subtitle.length > 0) {
-				subtitleElements[i].innerHTML = "";
-				subtitleElements[i].innerText = subtitle.join(", ");
+				playerUI.subtitles[i].innerHTML = "";
+				playerUI.subtitles[i].innerText = subtitle.join(", ");
 			} else {
-				subtitleElements[i].innerHTML = '<i style="opacity:0.5;">No Track Info</i>';
+				playerUI.subtitles[i].innerHTML = '<i style="opacity:0.5;">No Track Info</i>';
 			}
 		}
 
 		// fill track details
 		const date = song.date.trim();
-		const detailsElement = player.querySelector(".details");
 
 		if (date) {
-			detailsElement.innerText = `Exported on ${date}`;
+			playerUI.details.innerText = `Exported on ${date}`;
 		} else {
-			detailsElement.innerHTML = '<i style="opacity:0.5;">No Track Details</i>';
+			playerUI.details.innerHTML = '<i style="opacity:0.5;">No Track Details</i>';
 		}
 
 		// display duration
@@ -221,7 +227,7 @@ function createSPCPlayerUI(){
 			timer.target = song.duration;
 
 			const seconds = song.duration % 60;
-			trackDuration.innerText = `${Math.floor(song.duration / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
+			playerUI.trackDuration.innerText = `${Math.floor(song.duration / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
 		}
 		else
 		{
@@ -232,22 +238,21 @@ function createSPCPlayerUI(){
 		if(timer.target > 0)
 		{
 			const seconds = Math.floor(time % 60);
-			trackTimeElapsed.innerText = `${Math.floor(time / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
-			seekContainer.style.display = "flex";
+			playerUI.trackTimeElapsed.innerText = `${Math.floor(time / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
+			playerUI.seekContainer.style.display = "flex";
 		}
 		else
 		{
-			seekContainer.style.display = "none";
+			playerUI.seekContainer.style.display = "none";
 		}
 
 		// fill track list
-		const playlist = player.querySelector(".track-list");
 
 		if(song.files.length > 1)
 		{
-			while(playlist.lastChild !== null)
+			while(playerUI.playlist.lastChild !== null)
 			{
-				playlist.removeChild(playlist.lastChild);
+				playerUI.playlist.removeChild(playerUI.playlist.lastChild);
 			}
 
 			const files = song.files;
@@ -264,14 +269,14 @@ function createSPCPlayerUI(){
 			const prefix = files[0].slice(0, common).lastIndexOf("/") + 1;
 
 			files.forEach((file, index) => {
-				playlist.appendChild(SMWCentral.SPCPlayer.createPlaylistItem(song, file.slice(prefix), index));
+				playerUI.playlist.appendChild(SMWCentral.SPCPlayer.createPlaylistItem(song, file.slice(prefix), index));
 			});
 
-			playlist.style.display = "block";
+			playerUI.playlist.style.display = "block";
 		}
 		else
 		{
-			playlist.style.display = "none";
+			playerUI.playlist.style.display = "none";
 		}
 
 		currentSong = song;
@@ -296,8 +301,8 @@ function createSPCPlayerUI(){
 		{
 			finished = true;
 
-			pause.classList.add("hidden");
-			play.classList.remove("hidden");
+			playerUI.pauseBtn.classList.add("hidden");
+			playerUI.playBtn.classList.remove("hidden");
 
 			SPCPlayer.stopSPC();
 
@@ -335,10 +340,10 @@ function createSPCPlayerUI(){
 		{
 			timer.lastUpdatedUI = time;
 
-			trackTimeElapsed.innerText = `${Math.floor(progress / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
+			playerUI.trackTimeElapsed.innerText = `${Math.floor(progress / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
 
 			const percentage = (progress / timer.target) * 100;
-			seekControl.style.backgroundImage = `linear-gradient(to right, var(--seek_fill) 0%, var(--seek_fill) ${percentage}%, var(--seek_bar) ${percentage}%)`;
+			playerUI.seekControl.style.backgroundImage = `linear-gradient(to right, var(--seek_fill) 0%, var(--seek_fill) ${percentage}%, var(--seek_bar) ${percentage}%)`;
 		}
 	};
 
@@ -390,16 +395,16 @@ function createSPCPlayerUI(){
 	});
 
 
-	pause.addEventListener("click", () => {
+	playerUI.pauseBtn.addEventListener("click", () => {
 		SPCPlayer.pause();
 
-		pause.classList.add("hidden");
-		play.classList.remove("hidden");
+		playerUI.pauseBtn.classList.add("hidden");
+		playerUI.playBtn.classList.remove("hidden");
 
 		SMWCentral.SPCPlayer.onPause();
 	});
 
-	play.addEventListener("click", () => {
+	playerUI.playBtn.addEventListener("click", () => {
 		if(finished)
 		{
 			if(!document.body.classList.contains("fetching-song"))
@@ -412,14 +417,14 @@ function createSPCPlayerUI(){
 		{
 			SPCPlayer.resume();
 
-			pause.classList.remove("hidden");
-			play.classList.add("hidden");
+			playerUI.pauseBtn.classList.remove("hidden");
+			playerUI.playBtn.classList.add("hidden");
 		}
 
 		SMWCentral.SPCPlayer.onPlay();
 	});
 
-	player.querySelector(".restart").addEventListener("click", () => {
+	playerUI.restartBtn.addEventListener("click", () => {
 		if(document.body.classList.contains("fetching-song"))
 		{
 			return;
@@ -431,7 +436,7 @@ function createSPCPlayerUI(){
 		SMWCentral.SPCPlayer.onRestart();
 	});
 
-	player.querySelector(".stop").addEventListener("click", () => {
+	playerUI.stopBtn.addEventListener("click", () => {
 		if(document.body.classList.contains("fetching-song"))
 		{
 			return;
@@ -443,7 +448,7 @@ function createSPCPlayerUI(){
 		SMWCentral.SPCPlayer.onStop();
 	});
 
-	seekControl.addEventListener("mousemove", (event) => {
+	playerUI.seekControl.addEventListener("mousemove", (event) => {
 		if(timer.target <= 0)
 		{
 			return;
@@ -454,11 +459,11 @@ function createSPCPlayerUI(){
 		const seconds = Math.round(Math.min(Math.max((timer.target * position) / range, 0), timer.target));
 		const fraction = seconds % 60;
 
-		seekPreview.innerText = `${Math.floor(seconds / 60)}:${(fraction > 9) ? "" : "0"}${fraction}`;
-		seekPreview.style.transform = `translate(calc(${position}px - 50%), 0)`;
+		playerUI.seekPreview.innerText = `${Math.floor(seconds / 60)}:${(fraction > 9) ? "" : "0"}${fraction}`;
+		playerUI.seekPreview.style.transform = `translate(calc(${position}px - 50%), 0)`;
 	});
 
-	seekControl.addEventListener("mouseup", (event) => {
+	playerUI.seekControl.addEventListener("mouseup", (event) => {
 		if(document.body.classList.contains("fetching-song") || timer.target <= 0)
 		{
 			return;

--- a/src/interface.js
+++ b/src/interface.js
@@ -241,11 +241,12 @@ function createSPCPlayerUI(){
 		{
 			const seconds = Math.floor(time % 60);
 			playerUI.trackTimeElapsed.innerText = `${Math.floor(time / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
-			playerUI.seekContainer.classList.remove("hidden");
+			playerUI.trackTimeElapsed.style.opacity = `1`
 		}
 		else
 		{
-			playerUI.seekContainer.classList.add("hidden");
+			playerUI.trackTimeElapsed.innerText = `ERR`
+			playerUI.trackTimeElapsed.style.opacity = `0.5`
 		}
 
 		// fill track list
@@ -329,6 +330,7 @@ function createSPCPlayerUI(){
 			|| SPCPlayer.spcPointer === null
 		)
 		{
+			playerUI.seekControl.style.backgroundImage = `none`; // reset seek bar
 			return;
 		}
 

--- a/src/interface.js
+++ b/src/interface.js
@@ -239,11 +239,11 @@ function createSPCPlayerUI(){
 		{
 			const seconds = Math.floor(time % 60);
 			playerUI.trackTimeElapsed.innerText = `${Math.floor(time / 60)}:${(seconds > 9) ? "" : "0"}${seconds}`;
-			playerUI.seekContainer.style.display = "flex";
+			playerUI.seekContainer.classList.remove("hidden");
 		}
 		else
 		{
-			playerUI.seekContainer.style.display = "none";
+			playerUI.seekContainer.classList.add("hidden");
 		}
 
 		// fill track list
@@ -272,11 +272,11 @@ function createSPCPlayerUI(){
 				playerUI.playlist.appendChild(SMWCentral.SPCPlayer.createPlaylistItem(song, file.slice(prefix), index));
 			});
 
-			playerUI.playlist.style.display = "block";
+			playerUI.playlist.classList.remove("hidden");
 		}
 		else
 		{
-			playerUI.playlist.style.display = "none";
+			playerUI.playlist.classList.add("hidden");
 		}
 
 		currentSong = song;

--- a/src/interface.js
+++ b/src/interface.js
@@ -73,12 +73,12 @@ function createSPCPlayerUI(){
 		volumeThumb: player.querySelector(".volume-thumb")
 	};
 
-	let volume = Number(sessionStorage.getItem("spc_volume") || 1);
-
 	let currentSong = null;
 
 	let finished = false;
 	let timer = {lastUpdatedUI: -1, target: 0, finish: 0, fade: 0, element: null};
+
+	let volume = Number(sessionStorage.getItem("spc_volume") || 1);
 
 	if(Number.isNaN(volume))
 	{
@@ -129,30 +129,15 @@ function createSPCPlayerUI(){
 		updateVolumeSlider();
 	};
 
-	playerUI.volumeSlider.addEventListener("input", updateVolume);
-
-	playerUI.volumeSlider.addEventListener("wheel", (e) => {
-		e.preventDefault();
-		const step = 0.05;
-		if (e.deltaY < 0) {
-			volume = Math.min(1.5, volume + step);
-		} else {
-			volume = Math.max(0, volume - step);
-		}
-		playerUI.volumeSlider.value = volume.toFixed(2);
-		updateVolumeSlider();
-	});
-
 	// hack to set slider position on load
-	const initSlider = () => {
+	const initVolumeSlider = () => {
 		if (playerUI.volumeThumb.getBoundingClientRect().width) {
 			playerUI.volumeSlider.value = volume;
 			updateVolumeSlider();
 		} else {
-			requestAnimationFrame(initSlider);
+			requestAnimationFrame(initVolumeSlider);
 		}
 	};
-	initSlider();
 
 	const loadSong = (song, time = 0) => {
 		if(SPCPlayer.status < 0)
@@ -384,19 +369,35 @@ function createSPCPlayerUI(){
 	};
 
 	updateVolume();
+	initVolumeSlider();
 
+	// player state listeners
 	toggle.checked = (sessionStorage.getItem("spc_collapsed") === "true");
-	loop.checked = (sessionStorage.getItem("spc_loop") !== "false");
-
 	toggle.addEventListener("change", (event) => {
 		sessionStorage.setItem("spc_collapsed", (event.target.checked) ? "true" : "false");
 	});
 
+	loop.checked = (sessionStorage.getItem("spc_loop") !== "false");
 	loop.addEventListener("change", (event) => {
 		sessionStorage.setItem("spc_loop", (event.target.checked) ? "true" : "false");
 	});
 
+	// volume control listeners
+	playerUI.volumeSlider.addEventListener("input", updateVolume);
 
+	playerUI.volumeSlider.addEventListener("wheel", (e) => {
+		e.preventDefault();
+		const step = 0.05;
+		if (e.deltaY < 0) {
+			volume = Math.min(1.5, volume + step);
+		} else {
+			volume = Math.max(0, volume - step);
+		}
+		playerUI.volumeSlider.value = volume.toFixed(2);
+		updateVolumeSlider();
+	});
+
+	// playback control listeners
 	playerUI.pauseBtn.addEventListener("click", () => {
 		SPCPlayer.pause();
 
@@ -450,6 +451,7 @@ function createSPCPlayerUI(){
 		SMWCentral.SPCPlayer.onStop();
 	});
 
+	// seek control listeners
 	playerUI.seekControl.addEventListener("mousemove", (event) => {
 		if(timer.target <= 0)
 		{

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -29,7 +29,6 @@
 				<div class="group-left">
 					<a class="play hidden" title="Resume song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M7 5v14l12-7Z"></path></svg></a>
 					<a class="pause" title="Pause song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path></svg></a>
-					<a id="spc-player-skip" class="hidden" title="Skip song"><svg height="24" viewBox="0 0 24 24" width="24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"></path></svg></a>
 					<a class="restart" title="Restart song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 12,5 V 1 l -5,5 5,5 V 7 c 3.31,0 6,2.69 6,6 0,3.31 -2.69,6 -6,6 C 8.69,19 6,16.31 6,13 H 4 c 0,4.42 3.58,8 8,8 4.42,0 8,-3.58 8,-8 0,-4.42 -3.58,-8 -8,-8 z"></path></svg></a>
 					<label for="spc-player-loop" class="loop" title="Toggle looping"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"></path></svg></label>
 				</div>
@@ -46,9 +45,6 @@
 				</div>
 			</div>
 			<ul class="track-list hidden"></ul>
-			<div id="spc-player-up-next" class="up-next hidden">
-				<span>Up Next: </span><a id="spc-player-up-next-link" title="Opens in a new tab" target="_blank"></a>
-			</div>
 		</div>
 	</div>
 </div>

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -20,7 +20,7 @@
 				<h3 class="subtitle"></h3>
 				<div class="details"></div>
 			</div>
-			<div class="seek-container" style="display: none;">
+			<div class="seek-container hidden">
 				<span class="track-time-elapsed"></span>
 				<div class="seek"><span class="seek-preview"></span></div>
 				<span class="track-duration"></span>
@@ -29,7 +29,7 @@
 				<div class="group-left">
 					<a class="play hidden" title="Resume song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M7 5v14l12-7Z"></path></svg></a>
 					<a class="pause" title="Pause song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path></svg></a>
-					<a id="spc-player-skip" class="hidden" title="Skip song" style="display: none;"><svg height="24" viewBox="0 0 24 24" width="24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"></path></svg></a>
+					<a id="spc-player-skip" class="hidden" title="Skip song"><svg height="24" viewBox="0 0 24 24" width="24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"></path></svg></a>
 					<a class="restart" title="Restart song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 12,5 V 1 l -5,5 5,5 V 7 c 3.31,0 6,2.69 6,6 0,3.31 -2.69,6 -6,6 C 8.69,19 6,16.31 6,13 H 4 c 0,4.42 3.58,8 8,8 4.42,0 8,-3.58 8,-8 0,-4.42 -3.58,-8 -8,-8 z"></path></svg></a>
 					<label for="spc-player-loop" class="loop" title="Toggle looping"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"></path></svg></label>
 				</div>
@@ -45,8 +45,8 @@
 					</div>
 				</div>
 			</div>
-			<ul class="track-list" style="display: none;"></ul>
-			<div id="spc-player-up-next" class="up-next" style="display: none;">
+			<ul class="track-list hidden"></ul>
+			<div id="spc-player-up-next" class="up-next hidden">
 				<span>Up Next: </span><a id="spc-player-up-next-link" title="Opens in a new tab" target="_blank"></a>
 			</div>
 		</div>

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -1,22 +1,22 @@
 <div id="spc-player-container">
 	<input type="checkbox" id="spc-player-toggle">
-	<input type="checkbox" id="spc-player-loop" checked="">
+	<input type="checkbox" id="spc-player-loop" checked>
 	<div id="spc-player-interface" class="spc-player">
 		<div id="spc-player-header" class="header">
 			<div class="group-left">
-				<label for="spc-player-toggle" class="toggle" title="Toggle player"><svg width="24" height="24" viewBox="0 0 24 24" class="shrink"><path d="m 9,5 3,3 3,-3 z m -4,6 v 2 h 14 v -2 z m 7,5 -3,3 h 6 z"></path></svg><svg width="24" height="24" viewBox="0 0 24 24" class="expand"><path d="m 9,7 3,-3 3,3 z m -4,4 v 2 h 14 v -2 z m 7,9 -2.798151,-3 H 15 Z"></path></svg></label>
+				<label for="spc-player-toggle" class="toggle header-button" title="<?= __('preview.spc.toggle', 'section') ?>"><?= svg('spc_player/shrink') ?><?= svg('spc_player/expand') ?></label>
 				<span>SPC Player</span>
 			</div>
 			<div class="now-playing">
 				<span class="title"></span>
 			</div>
 			<div class="group-right">
-				<a class="stop close" title="Close"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 7.3847656,5.6152344 5.6152344,7.3847656 10.230469,12 5.6152344,16.615234 7.3847656,18.384766 12,13.769531 16.615234,18.384766 18.384766,16.615234 13.769531,12 18.384766,7.3847656 16.615234,5.6152344 12,10.230469 Z"></path></svg></a>
+				<a class="stop close header-button" title="<?= __('preview.spc.close', 'section') ?>"><?= svg('spc_player/close') ?></a>
 			</div>
 		</div>
-		<div id="spc-player-content" class="content">
+		<div id="spc-player-content" class="player-content">
 			<div class="track-info">
-				<h2 class="title">Song Title</h2>
+				<h2 class="title"><?= __('preview.spc.title', 'section') ?></h2>
 				<h3 class="subtitle"></h3>
 				<div class="details"></div>
 			</div>
@@ -27,16 +27,17 @@
 			</div>
 			<div id="spc-player-controls" class="controls">
 				<div class="group-left">
-					<a class="play hidden" title="Resume song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M7 5v14l12-7Z"></path></svg></a>
-					<a class="pause" title="Pause song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path></svg></a>
-					<a class="restart" title="Restart song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 12,5 V 1 l -5,5 5,5 V 7 c 3.31,0 6,2.69 6,6 0,3.31 -2.69,6 -6,6 C 8.69,19 6,16.31 6,13 H 4 c 0,4.42 3.58,8 8,8 4.42,0 8,-3.58 8,-8 0,-4.42 -3.58,-8 -8,-8 z"></path></svg></a>
-					<label for="spc-player-loop" class="loop" title="Toggle looping"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"></path></svg></label>
+					<a class="play hidden" title="<?= __('preview.spc.resume', 'section') ?>"><?= svg('spc_player/play') ?></a>
+					<a class="pause" title="<?= __('preview.spc.pause', 'section') ?>"><?= svg('spc_player/pause') ?></a>
+					<a id="spc-player-skip" class="hidden" title="<?= __('preview.spc.skip', 'section') ?>"><?= svg('spc_player/skip') ?></a>
+					<a class="restart" title="<?= __('preview.spc.restart', 'section') ?>"><?= svg('spc_player/restart') ?></a>
+					<label for="spc-player-loop" class="loop" title="<?= __('preview.spc.loop', 'section') ?>"><?= svg('spc_player/loop') ?></label>
 				</div>
 				<div id="spc-player-volume" class="volume">
 					<span class="volume-level">100%</span>
-					<svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path></svg>
+					<?= svg('spc_player/volume') ?>
 					<div class="volume-control">
-						<input type="range" id="volume-slider" title="Volume">
+						<input type="range" id="volume-slider" title="<?= __('preview.spc.volume', 'section') ?>">
 						<div class="volume-track">
 							<div class="volume-fill"></div>
 							<div class="volume-thumb"></div>
@@ -44,7 +45,16 @@
 					</div>
 				</div>
 			</div>
-			<ul class="track-list hidden"></ul>
+			<div id="track-list-container" class="hidden">
+				<div class="overflow-indicator top"></div>
+				<div class="track-list-scrollbox">
+					<ul class="track-list"></ul>
+				</div>
+				<div class="overflow-indicator bottom"></div>
+			</div>
+			<div id="spc-player-up-next" class="up-next hidden">
+				<span><?= __('preview.spc.up_next', 'section') ?></span><a id="spc-player-up-next-link" title="Opens in a new tab" target="_blank"></a>
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -1,28 +1,54 @@
-<input type="checkbox" id="spc-player-toggle">
-<input type="checkbox" id="spc-player-loop" checked>
-<input type="checkbox" id="spc-player-move">
-<div id="spc-player-interface" class="spc-player">
-	<div class="header">
-		<div class="group-left">
-			<label for="spc-player-toggle" class="toggle" title="Toggle player"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z" /></svg></label>
-			<a class="pause" title="Pause song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" /></svg></a>
-			<a class="play hidden" title="Resume song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" /></svg></a>
+<div id="spc-player-container">
+	<input type="checkbox" id="spc-player-toggle">
+	<input type="checkbox" id="spc-player-loop" checked="">
+	<div id="spc-player-interface" class="spc-player">
+		<div id="spc-player-header" class="header">
+			<div class="group-left">
+				<label for="spc-player-toggle" class="toggle" title="Toggle player"><svg width="24" height="24" viewBox="0 0 24 24" class="shrink"><path d="m 9,5 3,3 3,-3 z m -4,6 v 2 h 14 v -2 z m 7,5 -3,3 h 6 z"></path></svg><svg width="24" height="24" viewBox="0 0 24 24" class="expand"><path d="m 9,7 3,-3 3,3 z m -4,4 v 2 h 14 v -2 z m 7,9 -2.798151,-3 H 15 Z"></path></svg></label>
+				<span>SPC Player</span>
+			</div>
+			<div class="now-playing">
+				<span class="title"></span>
+			</div>
+			<div class="group-right">
+				<a class="stop close" title="Close"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 7.3847656,5.6152344 5.6152344,7.3847656 10.230469,12 5.6152344,16.615234 7.3847656,18.384766 12,13.769531 16.615234,18.384766 18.384766,16.615234 13.769531,12 18.384766,7.3847656 16.615234,5.6152344 12,10.230469 Z"></path></svg></a>
+			</div>
 		</div>
-		<div class="group-right">
-			<label for="spc-player-loop" class="loop" title="Toggle looping"><svg class="check" width="16" height="16" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" /></svg><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z" /></svg></label>
-			<a class="restart" title="Restart song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z" /></svg></a>
-			<a class="stop" title="Stop song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 6h12v12H6z" /></svg></a>
+		<div id="spc-player-content" class="content">
+			<div class="track-info">
+				<h2 class="title">Song Title</h2>
+				<h3 class="subtitle" style="display: none;"></h3>
+				<div class="details" style="display: none;"></div>
+			</div>
+			<div class="seek-container" style="display: none;">
+				<span class="track-time-elapsed"></span>
+				<div class="seek"><span class="seek-preview"></span></div>
+				<span class="track-duration"></span>
+			</div>
+			<div id="spc-player-controls" class="controls">
+				<div class="group-left">
+					<a class="play hidden" title="Resume song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M7 5v14l12-7Z"></path></svg></a>
+					<a class="pause" title="Pause song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"></path></svg></a>
+					<a id="spc-player-skip" class="hidden" title="Skip song" style="display: none;"><svg height="24" viewBox="0 0 24 24" width="24"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"></path></svg></a>
+					<a class="restart" title="Restart song"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M 12,5 V 1 l -5,5 5,5 V 7 c 3.31,0 6,2.69 6,6 0,3.31 -2.69,6 -6,6 C 8.69,19 6,16.31 6,13 H 4 c 0,4.42 3.58,8 8,8 4.42,0 8,-3.58 8,-8 0,-4.42 -3.58,-8 -8,-8 z"></path></svg></a>
+					<label for="spc-player-loop" class="loop" title="Toggle looping"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M12 4V1L8 5l4 4V6c3.31 0 6 2.69 6 6 0 1.01-.25 1.97-.7 2.8l1.46 1.46C19.54 15.03 20 13.57 20 12c0-4.42-3.58-8-8-8zm0 14c-3.31 0-6-2.69-6-6 0-1.01.25-1.97.7-2.8L5.24 7.74C4.46 8.97 4 10.43 4 12c0 4.42 3.58 8 8 8v3l4-4-4-4v3z"></path></svg></label>
+				</div>
+				<div id="spc-player-volume" class="volume">
+					<span class="volume-level">100%</span>
+					<svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path></svg>
+					<div class="volume-control">
+						<input type="range" id="volume-slider" title="Volume">
+						<div class="volume-track">
+							<div class="volume-fill"></div>
+							<div class="volume-thumb"></div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<ul class="track-list" style="display: none;"></ul>
+			<div id="spc-player-up-next" class="up-next" style="display: none;">
+				<span>Up Next: </span><a id="spc-player-up-next-link" title="Opens in a new tab" target="_blank"></a>
+			</div>
 		</div>
 	</div>
-	<h2>Song Title</h2>
-	<h3 style="display: none;"></h3>
-	<aside style="display: none;"></aside>
-	<div class="seek" style="display: none;"><span></span></div>
-	<ul style="display: none;"></ul>
-	<div class="volume">
-		<svg width="24" height="24" viewBox="0 0 24 24"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" /></svg>
-		<span>100%</span>
-		<div class="volume-control"><div class="slider" title="Volume"><div class="fill"></div></div></div>
-	</div>
-	<label for="spc-player-move" class="move" title="Move player"><svg width="24" height="24" viewBox="0 0 24 24"><path d="M14 7l-5 5 5 5V7z" /></svg></label>
 </div>

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -20,7 +20,7 @@
 				<h3 class="subtitle"></h3>
 				<div class="details"></div>
 			</div>
-			<div class="seek-container hidden">
+			<div class="seek-container">
 				<span class="track-time-elapsed"></span>
 				<div class="seek"><span class="seek-preview"></span></div>
 				<span class="track-duration"></span>

--- a/src/spc_player.html
+++ b/src/spc_player.html
@@ -17,8 +17,8 @@
 		<div id="spc-player-content" class="content">
 			<div class="track-info">
 				<h2 class="title">Song Title</h2>
-				<h3 class="subtitle" style="display: none;"></h3>
-				<div class="details" style="display: none;"></div>
+				<h3 class="subtitle"></h3>
+				<div class="details"></div>
 			</div>
 			<div class="seek-container" style="display: none;">
 				<span class="track-time-elapsed"></span>

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -1,337 +1,504 @@
-$bg_color: #121314;
-$border_color: rgba(white,0.1);
-$border_radius: 6px;
+:root {
+	--player_bg: rgba(18, 19, 20, 0.9);
+	--player_text: #fff;
+	--player_borders: color-mix(in srgb, var(--player_text), transparent 85%);
 
-@mixin toggled() {
+	// used by interface.js
+	--seek_fill: #16bc10;
+	--seek_bar: color-mix(in srgb, var(--player_text), transparent 85%);
+
+	--volume_fill: #338fdf;
+	--volume_overfill: #dfc033;
+	--volume_bar: color-mix(in srgb, var(--player_text), transparent 85%);
+}
+
+@mixin player-toggled() {
 	[id="spc-player-toggle"]:checked ~ & {
 		@content;
 	}
 }
 
-@mixin moved() {
-	[id="spc-player-move"]:checked ~ & {
+@mixin mobile-small() {
+	@media screen and (max-width: 480px) {
 		@content;
 	}
 }
 
-body.fetching-song {
-	cursor: progress;
 
-	.spc-player .header a.restart,
-	.spc-player .header a.stop,
-	.spc-player li {
-		cursor: wait;
+@keyframes marquee {
+	0%   { transform: translateX(0); }
+	100% { transform: translateX(-100%); }
+}
+
+body {
+	&.fetching-song {
+		cursor: progress;
+
+		a[data-spc-file],
+		#spc-player-interface .controls a.restart,
+		#spc-player-interface .controls a.stop,
+		#spc-player-interface .controls a.skip,
+		#spc-player-interface li {
+			cursor: wait;
+		}
+	}
+
+	&.has-script .no-script,
+	&:not(.has-script) .script-only {
+		display: none;
 	}
 }
 
-#spc-player-toggle, #spc-player-loop, #spc-player-move {
+
+#spc-player-toggle,
+#spc-player-loop {
 	display: none;
 }
 
-.spc-player {
+#spc-player-interface {
 	width: 400px;
+	height: auto;
 	position: fixed;
-	right: 24px;
-	bottom: 0;
+	right: 16px;
+	bottom: 16px;
 	z-index: 10000;
-	background: $bg_color;
-	border-bottom: none;
-	border-radius: $border_radius*1.5 $border_radius*1.5 0 0;
-	box-shadow: 0 0 0 6px $border_color;
+	background: var(--player_bg);
+  	backdrop-filter: blur(7px);
+	border-radius: 12px;
+	box-shadow:
+		0 0px 0px 3px rgba(white, 0.1),
+		0 2px 4px 4px rgba(black, 0.2),
+		0 2px 6px 4px rgba(black, 0.04);
 	transition: all 220ms;
+	overflow: hidden;
 
-	@include toggled {
-		transform: translate(0, calc(100% - 66px));
+	will-change: transform;
+	transform: translate3d(0,0,0);
+
+	&:not(.shown) {
+		display: none;
 	}
 
-	[id="spc-player-toggle"] ~ &:not(.shown) {
-		transform: translate(0, 100%);
+	svg {
+		fill: var(--player_text);
 	}
 
-	@include moved {
-		right: auto;
-		left: 24px;
+	* {
+		color: var(--player_text);
 	}
 
+	@include mobile-small {
+		left: auto;
+		right: 6px;
+		bottom: 6px;
+		width: calc(100% - 12px);
+		border-radius: 8px;
+	}
+
+	// header
 	.header {
 		display: flex;
 		justify-content: space-between;
-		padding: 8px;
-		transition: padding 220ms;
-		border-bottom: 1px solid $border_color;
+		gap: 8px;
+		padding: 6px;
+		border-bottom: 1px solid var(--player_borders);
+		cursor: move;
+		user-select: none;
+
+		@include mobile-small {
+			cursor: default;
+		}
 
 		& > div {
 			display: flex;
+			gap: 6px;
 		}
 
-		a, label {
+		span {
+			font-weight: bold;
+			height: 24px;
+			line-height: 24px;
+		}
+
+		a,
+		label {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			box-sizing: border-box;
+			width: 24px;
+			height: 24px;
+			border-radius: 6px;
+			cursor: pointer;
+
+			&:hover {
+				background-image: none;
+				background: color-mix(in srgb, var(--player_bg), white 20%);
+			}
+
+			&.toggle > svg {
+				transition: display ease 100ms;
+
+				&.expand { display: none; }
+				&.shrink { display: inline;	}
+
+				@include player-toggled {
+					&.expand { display: inline;	}
+					&.shrink { display: none; }
+				}
+			}
+		}
+
+		// now playing
+		.now-playing {
+			overflow: hidden;
+			white-space: nowrap;
+			box-sizing: border-box;
+			flex: 1;
+			user-select: none;
+
+			.title {
+				display: none;
+				padding-left: 100%;
+				animation: marquee 10s linear infinite;
+				font-size: 13px !important;
+
+				@include player-toggled {
+					display: inline-block;
+				}
+			}
+		}
+
+	}
+
+	// player window content
+	.player-content {
+		display: flex;
+		padding: 8px;
+		flex-direction: column;
+		gap: 8px;
+
+		@include player-toggled {
+			padding: 4px;
+		}
+	}
+
+	// player controls
+	.controls {
+		display: flex;
+		justify-content: space-between;
+		padding-top: 8px;
+		border-top: 1px solid var(--player_borders);
+
+		@include player-toggled {
+			display: none;
+		}
+
+		& > div {
+			display: flex;
+			gap: 8px;
+		}
+
+		a,
+		label {
 			display: inline-flex;
 			align-items: center;
 			justify-content: center;
 			box-sizing: border-box;
 			width: 30px;
 			height: 30px;
-			margin: 0 4px;
-			background: rgba(white, 0.1);
-			border-radius: $border_radius;
+			border-radius: 6px;
 			cursor: pointer;
-			transition: all 220ms;
 
-			&:first-child {
-				margin-left: 0;
-			}
-
-			&:only-child {
-				margin-left: 0;
-				margin-right: 0;
-			}
-
-			&:last-child {
-				margin-right: 0;
-			}
+			background: color-mix(in srgb, var(--player_bg), white 13%);
 
 			&:hover {
-				background: rgba(white, 0.2);
+				background-image: none;
+				background: color-mix(in srgb, var(--player_bg), white 20%);
 			}
 
-			& > svg {
-				fill: #fff;
+			&.loop {
+				svg {
+					transition: transform 0.3s ease;
+				}
+
+				&:active svg {
+					transform: rotate(-90deg);
+				}
+
+				[id="spc-player-loop"]:checked ~ & {
+					background-color: color-mix(in srgb, var(--player_bg), rgb(117, 209, 255) 15%);
+					&:hover {
+						background-image: none;
+						background-color: color-mix(in srgb, var(--player_bg), rgb(117, 209, 255) 25%);
+					}
+
+					& > svg {
+						transform: rotate(-90deg);
+						fill: rgb(117, 209, 255);
+					}
+				}
 			}
 		}
 
-		@include toggled {
-			padding: 6px;
+		.hidden {
+			display: none;
+		}
+	}
+
+	// track info
+	.track-info {
+		display: flex;
+		flex-direction: column;
+		padding: 0 3px;
+		gap: 4px;
+
+		.title,
+		.subtitle {
+			overflow: hidden;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			color: inherit;
 		}
 
-		a.hidden {
+		.title {
+			font-size: 1.25em;
+			font-weight: 700;
+			transition: all 220ms;
+		}
+
+		.subtitle {
+			font-size: 1.09em;
+			font-weight: 400;
+			opacity: 0.8;
+		}
+
+		.details {
+			font-size: 0.93em;
+			line-height: 1em;
+			opacity: 0.5;
+		}
+
+		@include player-toggled {
 			display: none;
 		}
 
-		label.toggle > svg {
-			transition: transform 220ms;
+		@include mobile-small {
+			gap: 2px;
 
-			@include toggled {
-				transform: rotate(-180deg);
+			.title {
+				font-size: 1.07em;
+			}
+
+			.artist {
+				font-size: 0.93em;
+			}
+
+			.details {
+				font-size: smaller;
 			}
 		}
 	}
 
-	label.loop {
-		& > svg.check {
-			width: 0;
-			transition: all 220ms;
+
+	.seek-container {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 8px;
+		padding: 0 3px;
+
+		span {
+			user-select: none;
 		}
 
-		[id="spc-player-loop"]:checked ~ & {
-			width: 50px;
-			background: rgba(white, 0.2);
+		@include player-toggled {
+			font-size: smaller;
+			padding: 0 6px;
+		}
 
-			& > svg.check {
-				width: 16px;
-				margin-right: 2px;
+		// seek bar
+		.seek {
+			position: relative;
+			height: 10px;
+			border-radius: 5px;
+			flex: 1;
+			cursor: pointer;
+
+			@include player-toggled {
+				height: 8px;
 			}
 
-			&:hover {
-				background: rgba(white, 0.3);
+			> span {
+				display: none;
+				position: absolute;
+				bottom: 75%;
+				padding: 0 4px;
+				border-radius: 3px;
+				background: rgba(0,0,0,0.97);
+				pointer-events: none;
+			}
+
+			&:hover > span {
+				display: block;
+			}
+
+			@include mobile-small {
+				height: 8px;
 			}
 		}
 	}
 
-	h2, h3 {
-		margin: 4px 8px;
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		color: #fff;
-	}
-
-	h2 {
-		font-size: 1.25em;
-		font-weight: 700;
-		transition: all 220ms;
-
-		@include toggled {
-			font-size: 0.83em;
-			margin-top: 2px;
-		}
-	}
-
-	h3 {
-		font-size: 1.2em;
-		font-weight: 400;
-		opacity: 0.8;
-	}
-
-	aside {
-		margin: 4px 8px;
-
-		&.next {
-			border:none;
-		}
-	}
-
-	.seek {
-		position: relative;
-		height: 12px;
-		background: rgba(white, 0.1);
-		cursor: pointer;
-		margin: 8px;
-		border-radius: $border_radius;
-
-		> span {
-			display: none;
-			position: absolute;
-			bottom: 75%;
-			padding: 0 4px;
-			border-radius: $border_radius*0.5;
-			background: $bg_color;
-			pointer-events: none;
-			color: #fff;
-		}
-
-		&:hover > span {
-			display: block;
-		}
-	}
-
-	ul {
-		max-height: 90px;
-		margin: 8px;
-		background-color: rgba(white,.1);
-		border-radius: $border_radius;
+	// track list
+	ul.track-list {
+		max-height: 216px;
+		background: color-mix(in srgb, var(--player_bg), white 5%);
+		border-radius: 6px;
 		padding: 0;
 		overflow: auto;
-		color: #fff;
+		color: inherit;
 		list-style-type: none;
 		counter-reset: spcs;
+
+		@include player-toggled {
+			display: none !important;
+		}
+
+		@include mobile-small {
+			max-height: 160px;
+		}
+
+		li {
+			height: 36px;
+			line-height: 36px;
+			padding: 0 8px;
+			overflow: hidden;
+			background-color: transparent;
+			cursor: pointer;
+			white-space: nowrap;
+			text-overflow: ellipsis;
+			counter-increment: spcs;
+			transition: background-color 220ms;
+
+			&:nth-child(even) {
+				background: rgba(white, 0.03);
+			}
+
+			&:before {
+				content: counter(spcs) ". ";
+			}
+
+			&:hover {
+				background: rgba(white, 0.07);
+			}
+
+			&.playing {
+				padding-left: 28px;
+				background: rgba(white, 0.1)
+					url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNOCA1djE0bDExLTd6IiBmaWxsPSIjZmZmIi8+PC9zdmc+")
+					2px 6px / 22px 22px no-repeat;
+				pointer-events: none;
+				color: white;
+				font-weight: bold;
+			}
+
+			@include mobile-small {
+				height: 32px;
+				line-height: 32px;
+				font-size: 13px;
+
+				&.playing {
+					background-size: 18px;
+					padding-left: 22px;
+				}
+			}
+		}
 	}
 
-	li {
-		height: 36px;
-		line-height: 36px;
-		padding: 0 8px;
+	// up next
+	.up-next {
 		overflow: hidden;
-		background: rgba(white, 0.04);
-		cursor: pointer;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		counter-increment: spcs;
-		transition: background-color 220ms;
 
-		&:nth-child(even) {
-			background: rgba(white, 0.06);
-		}
+		padding: 0 3px;
+		padding-top: 6px;
+		border-top: 1px solid var(--player_borders);
 
-		&:before {
-			content: counter(spcs) ". ";
-		}
-
-		&:hover {
-			background: rgba(white, 0.1);
-		}
-
-		&.playing {
-			padding-left: 28px;
-			background: rgba(white, 0.2) url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNOCA1djE0bDExLTd6IiBmaWxsPSIjZmZmIi8+PC9zdmc+") 2px 6px / 22px 22px no-repeat;
-			pointer-events: none;
+		span {
+			font-weight: bold;
+			color: inherit;
 		}
 	}
 
+	// volume control
 	.volume {
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;
-		border-top: 1px solid $border_color;
+		gap: 6px !important;
 
-		& > span {
-			color: #fff;
+		.volume-level {
+			color: inherit;
 			user-select: none;
+			font-weight: bold;
+			text-align: left;
 		}
 
-		& > svg {
-			margin: 0 auto 0 8px;
-			fill: #fff;
-		}
+		// defines for volume control widget
+		$volume_slider_width: 96px;
+		$volume_slider_height: 6px;
+		$volume_handle_size: 20px;
 
-		& > .volume-control {
-			margin: 6px;
-			cursor: pointer;
-		}
+		.volume-control {
+  			position: relative;
+			width: $volume_slider_width;
+			height: $volume_slider_height;
 
-		.slider {
-			position: relative;
-			width: 96px;
-			height: 24px;
-			clip-path: polygon(100% 0%, 100% 100%, 0% 100%);
-			background-color: $border_color;
+			input[type="range"] {
+				position: absolute;
+				width: 100%;
+				height: $volume_handle_size;
+				// some wacky math to position the input behind the widget
+				top: calc(($volume_handle_size - $volume_slider_height) * 0.5 * -1);
+				opacity: 0; // invisible
+				z-index: 2;
+				cursor: pointer;
+			}
 
-			& > .fill {
+			.volume-track,
+			.volume-fill {
 				position: absolute;
 				top: 0;
-				right: 0;
-				bottom: 0;
 				left: 0;
-				background: linear-gradient(to right, #B5E61D 0%, #22B14C 66%, #FF7F27 80%, #ED1C24 100%);
+				height: 100%;
+				width: 100%;
+				border-radius: 8px;
+			}
+
+			.volume-track {
+				background: var(--volume_bar);
+
+				.volume-fill {
+					background: linear-gradient(to right, var(--volume_fill) 0%,  var(--volume_fill)  66%, var(--volume_overfill) 66%, var(--volume_overfill) 100%);
+					clip-path: inset(0 100% 0 0);
+					transition: clip-path 0.2s ease;
+				}
+
+				.volume-thumb {
+					position: absolute;
+					top: 50%;
+					left: 0%;
+					transform: translate(-50%, -50%);
+					width: $volume_handle_size;
+					height: $volume_handle_size;
+					background: var(--player_text);
+					border-radius: 50%;
+					transition: left 0.2s ease;
+					pointer-events: none;
+				}
 			}
 		}
-	}
 
-	.move {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		position: absolute;
-		bottom: 0;
-		left: -26px;
-		width: 26px;
-		height: 36px;
-		box-sizing: border-box;
-		background: $bg_color;
-		border-radius: $border_radius 0 0 0;
-		cursor: pointer;
-		transition: background-color 220ms, bottom 220ms, height 220ms;
-		box-shadow: 0 0 0 1px $border_color;
-
-		&:hover {
-			background: lighten($bg_color, 5%);
-		}
-
-		@include toggled {
-			bottom: calc(100% - 66px);
-			height: 23px;
-		}
-
-		@include moved {
-			right: -26px;
-			left: auto;
-			border-radius: 0 $border_radius 0 0;
-		}
-
-		& > svg {
-			fill: #fff;
-
-			@include moved {
-				transform: rotate(180deg);
-			}
-		}
-	}
-}
-
-// mobile
-@media only screen and (max-width:480px) {
-	.spc-player {
-		width: 100%;
-		left: auto;
-		right: 0;
-		bottom: 0;
-		border-radius: 0;
-
-		@include moved {
-			left: 0;
-			right: auto;
-		}
-	}
-	.move {
-		display: none;
 	}
 }

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -308,10 +308,21 @@ body {
 		justify-content: space-between;
 		align-items: center;
 		gap: 8px;
-		padding: 0 3px;
 
 		span {
 			user-select: none;
+
+			&.track-time-elapsed,
+			&.track-duration {
+				min-width: 30px;
+				font-variant-numeric: tabular-nums;
+			}
+			&.track-time-elapsed {
+				text-align: right;
+			}
+			&.track-duration {
+				text-align: left;
+			}
 		}
 
 		@include player-toggled {
@@ -326,6 +337,7 @@ body {
 			border-radius: 5px;
 			flex: 1;
 			cursor: pointer;
+			background-color: var(--seek_bar);
 
 			@include player-toggled {
 				height: 8px;

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -1,4 +1,5 @@
 :root {
+	// player UI colors
 	--player_bg: rgba(18, 19, 20, 0.9);
 	--player_text: #fff;
 	--player_borders: color-mix(in srgb, var(--player_text), transparent 85%);
@@ -7,9 +8,22 @@
 	--seek_fill: #16bc10;
 	--seek_bar: color-mix(in srgb, var(--player_text), transparent 85%);
 
+	// volume bar colors
 	--volume_fill: #338fdf;
 	--volume_overfill: #dfc033;
 	--volume_bar: color-mix(in srgb, var(--player_text), transparent 85%);
+
+	// button colors
+	--button_fill: color-mix(in srgb, var(--player_text), transparent 85%);
+	--button_hover_fill: color-mix(in srgb, var(--player_text), transparent 75%);
+	--button_active_fill: color-mix(in srgb, var(--player_text), transparent 75%);
+
+	--button_checked_fill: #75d1ff;
+
+	// list colors
+	--list_item_fill: color-mix(in srgb, var(--player_text), transparent 95%);
+	--list_item_hover_fill: color-mix(in srgb, var(--player_text), transparent 88%);
+	--list_item_active_fill: color-mix(in srgb, var(--player_text), transparent 83%);
 }
 
 @mixin player-toggled() {
@@ -82,7 +96,6 @@ body {
 		right: 6px;
 		bottom: 6px;
 		width: calc(100% - 12px);
-		border-radius: 8px;
 	}
 
 	// anchor player differently on large displays
@@ -141,8 +154,7 @@ body {
 			cursor: pointer;
 
 			&:hover {
-				background-image: none;
-				background: color-mix(in srgb, var(--player_text), transparent 80%);
+				background-color: var(--button_hover_fill);
 			}
 
 			&.toggle > svg {
@@ -212,7 +224,7 @@ body {
 
 		& > div {
 			display: flex;
-			gap: 8px;
+			gap: 6px;
 		}
 
 		a,
@@ -225,12 +237,10 @@ body {
 			height: 30px;
 			border-radius: 6px;
 			cursor: pointer;
-
-			background: color-mix(in srgb, var(--player_text), transparent 87%);
+			background-color: var(--button_fill);
 
 			&:hover {
-				background-image: none;
-				background: color-mix(in srgb, var(--player_text), transparent 80%);
+				background-color: var(--button_hover_fill);
 			}
 
 			&.loop {
@@ -243,15 +253,14 @@ body {
 				}
 
 				[id="spc-player-loop"]:checked ~ & {
-					background-color: color-mix(in srgb, var(--player_bg), rgb(117, 209, 255) 15%);
+					background-color: color-mix(in srgb, var(--button_checked_fill), transparent 70%);
 					&:hover {
-						background-image: none;
-						background-color: color-mix(in srgb, var(--player_bg), rgb(117, 209, 255) 25%);
+						background-color: color-mix(in srgb, var(--button_checked_fill), transparent 60%);
 					}
 
 					& > svg {
 						transform: rotate(-90deg);
-						fill: rgb(117, 209, 255);
+						fill: color-mix(in srgb, var(--button_checked_fill), var(--player_text) 50%);
 					}
 				}
 			}
@@ -325,7 +334,11 @@ body {
 			&.track-duration {
 				min-width: 30px;
 				font-variant-numeric: tabular-nums;
+				@include mobile-small {
+					font-size: 13px;
+				}
 			}
+
 			&.track-time-elapsed {
 				text-align: right;
 			}
@@ -336,7 +349,6 @@ body {
 
 		@include player-toggled {
 			font-size: smaller;
-			padding: 0 6px;
 		}
 
 		// seek bar
@@ -377,7 +389,6 @@ body {
 
 	#track-list-container {
 		position: relative;
-		border-radius: 6px;
 
 		@include player-toggled {
 			display: none !important;
@@ -406,14 +417,14 @@ body {
 				li {
 					height: $playlist_item_height;
 					line-height: $playlist_item_height;
-					border-radius: 4px;
+					border-radius: 6px;
 					padding: 0 8px;
 					overflow: hidden;
 					white-space: nowrap;
 					text-overflow: ellipsis;
 					counter-increment: spcs;
 					transition: background-color 220ms;
-					background: color-mix(in srgb, var(--player_text), transparent 95%);
+					background-color: var(--list_item_fill);
 					cursor: pointer;
 
 					&:before {
@@ -422,21 +433,20 @@ body {
 					}
 
 					&:hover {
-						background: color-mix(in srgb, var(--player_text), transparent 90%);
+						background-color: var(--list_item_hover_fill);
 					}
 
 					&.playing {
 						pointer-events: none;
 						font-weight: bold;
 						cursor: default;
-						background: color-mix(in srgb, var(--player_text), transparent 87%);
+						background-color: var(--list_item_active_fill);
 
 						// draw a play triangle without emoji rendering
 						&::before {
 							content: "▶⠀" counter(spcs) ".";
 							font-family: sans-serif;
-  							font-variant-emoji: text;
-							padding-right: 6px;
+							font-variant-emoji: text;
 						}
 					}
 
@@ -457,7 +467,7 @@ body {
 			pointer-events: none;
 
 			opacity: 0;
-			transition: opacity .1s ease;
+			transition: opacity 0.1s ease;
 
 			&.top {
 				top: 0;

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -416,22 +416,6 @@ body {
 		}
 	}
 
-	// up next
-	.up-next {
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-
-		padding: 0 3px;
-		padding-top: 6px;
-		border-top: 1px solid var(--player_borders);
-
-		span {
-			font-weight: bold;
-			color: inherit;
-		}
-	}
-
 	// volume control
 	.volume {
 		display: flex;

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -95,6 +95,11 @@ body {
 		border-radius: 8px;
 	}
 
+	// hidden elements
+	.hidden {
+		display: none !important;
+	}
+
 	// header
 	.header {
 		display: flex;
@@ -239,10 +244,6 @@ body {
 					}
 				}
 			}
-		}
-
-		.hidden {
-			display: none;
 		}
 	}
 

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -63,7 +63,7 @@ body {
 	bottom: 16px;
 	z-index: 10000;
 	background: var(--player_bg);
-  	backdrop-filter: blur(7px);
+	backdrop-filter: blur(7px);
 	border-radius: 12px;
 	box-shadow:
 		0 0px 0px 3px rgba(white, 0.1),
@@ -73,7 +73,23 @@ body {
 	overflow: hidden;
 
 	will-change: transform;
-	transform: translate3d(0,0,0);
+	transform: translate3d(0, 0, 0);
+
+	@include mobile-small {
+		left: auto;
+		right: 6px;
+		bottom: 6px;
+		width: calc(100% - 12px);
+		border-radius: 8px;
+	}
+
+	// anchor player differently on large displays
+	@media screen and (min-width: 2560px) {
+		bottom: 24px;
+		right: auto;
+		top: auto;
+		left: calc(50% + (880px - 400px));
+	}
 
 	&:not(.shown) {
 		display: none;
@@ -86,20 +102,6 @@ body {
 	* {
 		color: var(--player_text);
 	}
-
-	@include mobile-small {
-		left: auto;
-		right: 6px;
-		bottom: 6px;
-		width: calc(100% - 12px);
-		border-radius: 8px;
-	}
-
-	// hidden elements
-	.hidden {
-		display: none !important;
-	}
-
 	// header
 	.header {
 		display: flex;
@@ -138,7 +140,7 @@ body {
 
 			&:hover {
 				background-image: none;
-				background: color-mix(in srgb, var(--player_bg), white 20%);
+				background: color-mix(in srgb, var(--player_text), transparent 80%);
 			}
 
 			&.toggle > svg {
@@ -173,7 +175,6 @@ body {
 				}
 			}
 		}
-
 	}
 
 	// player window content
@@ -215,11 +216,11 @@ body {
 			border-radius: 6px;
 			cursor: pointer;
 
-			background: color-mix(in srgb, var(--player_bg), white 13%);
+			background: color-mix(in srgb, var(--player_text), transparent 87%);
 
 			&:hover {
 				background-image: none;
-				background: color-mix(in srgb, var(--player_bg), white 20%);
+				background: color-mix(in srgb, var(--player_text), transparent 80%);
 			}
 
 			&.loop {
@@ -336,7 +337,7 @@ body {
 				bottom: 75%;
 				padding: 0 4px;
 				border-radius: 3px;
-				background: rgba(0,0,0,0.97);
+				background: rgba(0, 0, 0, 0.97);
 				pointer-events: none;
 			}
 
@@ -350,68 +351,103 @@ body {
 		}
 	}
 
-	// track list
-	ul.track-list {
-		max-height: 216px;
-		background: color-mix(in srgb, var(--player_bg), white 5%);
+	// track list container
+	$playlist_item_height: 32px;
+
+	#track-list-container {
+		position: relative;
 		border-radius: 6px;
-		padding: 0;
-		overflow: auto;
-		color: inherit;
-		list-style-type: none;
-		counter-reset: spcs;
 
 		@include player-toggled {
 			display: none !important;
 		}
 
-		@include mobile-small {
-			max-height: 160px;
-		}
-
-		li {
-			height: 36px;
-			line-height: 36px;
-			padding: 0 8px;
-			overflow: hidden;
-			background-color: transparent;
-			cursor: pointer;
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			counter-increment: spcs;
-			transition: background-color 220ms;
-
-			&:nth-child(even) {
-				background: rgba(white, 0.03);
-			}
-
-			&:before {
-				content: counter(spcs) ". ";
-			}
-
-			&:hover {
-				background: rgba(white, 0.07);
-			}
-
-			&.playing {
-				padding-left: 28px;
-				background: rgba(white, 0.1)
-					url("data:image/svg+xml;charset=utf-8;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNOCA1djE0bDExLTd6IiBmaWxsPSIjZmZmIi8+PC9zdmc+")
-					2px 6px / 22px 22px no-repeat;
-				pointer-events: none;
-				color: white;
-				font-weight: bold;
-			}
+		// scroll box for the track list
+		.track-list-scrollbox {
+			max-height: calc($playlist_item_height * 6);
+			overflow-y: auto;
 
 			@include mobile-small {
-				height: 32px;
-				line-height: 32px;
-				font-size: 13px;
+				max-height: calc($playlist_item_height * 4);
+			}
 
-				&.playing {
-					background-size: 18px;
-					padding-left: 22px;
+			// track list
+			ul.track-list {
+				margin: 0;
+				padding: 0;
+				color: inherit;
+				list-style-type: none;
+				counter-reset: spcs;
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+
+				li {
+					height: $playlist_item_height;
+					line-height: $playlist_item_height;
+					border-radius: 4px;
+					padding: 0 8px;
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
+					counter-increment: spcs;
+					transition: background-color 220ms;
+					background: color-mix(in srgb, var(--player_text), transparent 95%);
+					cursor: pointer;
+
+					&:before {
+						content: counter(spcs) ". ";
+					}
+
+					&:hover {
+						background: color-mix(in srgb, var(--player_text), transparent 92%);
+					}
+
+
+					&.playing {
+						pointer-events: none;
+						font-weight: bold;
+						cursor: default;
+						background: color-mix(in srgb, var(--player_text), transparent 87%);
+
+						// draw a play triangle without emoji rendering
+						&::before {
+							content: "▶⠀" counter(spcs) ".";
+							font-family: sans-serif;
+  							font-variant-emoji: text;
+							padding-right: 6px;
+						}
+					}
+
+					@include mobile-small {
+						font-size: 13px;
+					}
 				}
+			}
+		}
+
+		// overflow indicators
+		.overflow-indicator {
+			position: absolute;
+			height: 16px;
+
+			left: 0;
+			right: 0;
+			pointer-events: none;
+
+			opacity: 0;
+			transition: opacity .1s ease;
+
+			&.top {
+				top: 0;
+				background: linear-gradient(to bottom, var(--player_bg) 0%, transparent 60%);
+			}
+			&.bottom {
+				bottom: 0;
+				background: linear-gradient(to top, var(--player_bg) 0%, transparent 60%);
+			}
+			&.visible {
+				opacity: 1;
 			}
 		}
 	}
@@ -436,7 +472,7 @@ body {
 		$volume_handle_size: 20px;
 
 		.volume-control {
-  			position: relative;
+			position: relative;
 			width: $volume_slider_width;
 			height: $volume_slider_height;
 
@@ -465,7 +501,13 @@ body {
 				background: var(--volume_bar);
 
 				.volume-fill {
-					background: linear-gradient(to right, var(--volume_fill) 0%,  var(--volume_fill)  66%, var(--volume_overfill) 66%, var(--volume_overfill) 100%);
+					background: linear-gradient(
+						to right,
+						var(--volume_fill) 0%,
+						var(--volume_fill) 66%,
+						var(--volume_overfill) 66%,
+						var(--volume_overfill) 100%
+					);
 					clip-path: inset(0 100% 0 0);
 					transition: clip-path 0.2s ease;
 				}
@@ -484,6 +526,10 @@ body {
 				}
 			}
 		}
+	}
 
+	// hidden elements
+	.hidden {
+		display: none !important;
 	}
 }

--- a/src/spc_player.scss
+++ b/src/spc_player.scss
@@ -24,10 +24,13 @@
 	}
 }
 
-
 @keyframes marquee {
-	0%   { transform: translateX(0); }
-	100% { transform: translateX(-100%); }
+	0% {
+		transform: translateX(0);
+	}
+	100% {
+		transform: translateX(-100%);
+	}
 }
 
 body {
@@ -48,7 +51,6 @@ body {
 		display: none;
 	}
 }
-
 
 #spc-player-toggle,
 #spc-player-loop {
@@ -146,12 +148,20 @@ body {
 			&.toggle > svg {
 				transition: display ease 100ms;
 
-				&.expand { display: none; }
-				&.shrink { display: inline;	}
+				&.expand {
+					display: none;
+				}
+				&.shrink {
+					display: inline;
+				}
 
 				@include player-toggled {
-					&.expand { display: inline;	}
-					&.shrink { display: none; }
+					&.expand {
+						display: inline;
+					}
+					&.shrink {
+						display: none;
+					}
 				}
 			}
 		}
@@ -302,7 +312,6 @@ body {
 		}
 	}
 
-
 	.seek-container {
 		display: flex;
 		justify-content: space-between;
@@ -408,13 +417,13 @@ body {
 					cursor: pointer;
 
 					&:before {
-						content: counter(spcs) ". ";
+						content: counter(spcs) ".";
+						padding-right: 6px;
 					}
 
 					&:hover {
-						background: color-mix(in srgb, var(--player_text), transparent 92%);
+						background: color-mix(in srgb, var(--player_text), transparent 90%);
 					}
-
 
 					&.playing {
 						pointer-events: none;


### PR DESCRIPTION
- replace the custom volume input with a standard range input
- use a custom html widget to style the volume input as a slider with a handle
- refresh the stylesheet, and use CSS standard variables
- be more specific with the seek widget's classes and move the time labels into seek container
- use classes for other text elements instead of querying tags
- port the upstream changes from SMW Central to the html
- define the PlayerUI elements as its own object to clean up references
- add overflow indication for the track list element on scroll
